### PR TITLE
V3.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+
 # Translations
 *.mo
 *.pot
@@ -146,6 +147,7 @@ dmypy.json
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+test.py
 
 # AWS User-specific
 .idea/**/aws.xml

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The video-hash-values for identical or near-duplicate videos are the same or sim
 
 ## <img src="https://github.githubassets.com/images/icons/emoji/unicode/1f3d7.png" width="20"></img> Installation
 
-To use this software, you must have [FFmpeg](https://ffmpeg.org/) installed. Please read [how to install FFmpeg](https://github.com/akamhy/videohash/wiki/Install-FFmpeg,-but-how%3F) if you don't already know how.
+To use this software, you must have [FFmpeg](https://ffmpeg.org/) installed. Please read [how to install FFmpeg](https://github.com/demmenie/videohash2/wiki/Install-FFmpeg,-but-how%3F) if you don't already know how.
 
 #### Install videohash2
 
@@ -121,9 +121,9 @@ False
 >>> 
 ```
 
-**Extended Usage** : <https://github.com/akamhy/videohash/wiki/Extended-Usage>
+**Extended Usage** : <https://github.com/demmenie/videohash2/wiki/Extended-Usage>
 
-**API Reference** : <https://github.com/akamhy/videohash/wiki/API-Reference>
+**API Reference** : <https://github.com/demmenie/videohash2/wiki/API-Reference>
 
 --------------------------------------------------------------------------
 

--- a/tests/test_framesextractor.py
+++ b/tests/test_framesextractor.py
@@ -12,22 +12,27 @@ script_path = os.path.dirname(os.path.realpath(__file__))
 def test_all():
     video_path = os.path.join(script_path, os.path.pardir, "assets", "rocket.mkv")
     output_dir = create_and_return_temporary_directory()
+    video_length = 52.3
     interval = 1
     ffmpeg_path = None
-    FramesExtractor(video_path, output_dir, interval=interval, ffmpeg_path=ffmpeg_path)
+    FramesExtractor(video_path, output_dir, video_length,
+                    interval=interval, ffmpeg_path=ffmpeg_path)
 
     with pytest.raises(FileNotFoundError):
         video_path = os.path.join(script_path, "thisvideodoesnotexist.mp4")
         output_dir = create_and_return_temporary_directory()
-        FramesExtractor(video_path, output_dir, interval=1, ffmpeg_path=None)
+        FramesExtractor(video_path, output_dir, video_length, interval=1,
+                        ffmpeg_path=None)
 
     with pytest.raises(FFmpegNotFound):
         video_path = os.path.join(script_path, os.path.pardir, "assets", "rocket.mkv")
         output_dir = create_and_return_temporary_directory()
         ffmpeg_path = os.path.join(output_dir, "ffmpeg")
-        FramesExtractor(video_path, output_dir, interval=1, ffmpeg_path=ffmpeg_path)
+        FramesExtractor(video_path, output_dir, video_length, interval=1,
+                        ffmpeg_path=ffmpeg_path)
 
     with pytest.raises(FramesExtractorOutPutDirDoesNotExist):
         video_path = os.path.join(script_path, "../assets/rocket.mkv")
         output_dir = os.path.join(script_path, "thisdirdoesnotexist/")
-        FramesExtractor(video_path, output_dir, interval=1, ffmpeg_path=None)
+        FramesExtractor(video_path, output_dir, video_length, interval=1,
+                        ffmpeg_path=None)

--- a/videohash2/__version__.py
+++ b/videohash2/__version__.py
@@ -6,7 +6,7 @@ __description__ = (
 )
 
 __url__ = "https://demmenie.github.io/videohash2/"
-__version__ = "3.0.3"
+__version__ = "3.1.0"
 __status__ = "production"
 __author__ = "Akash Mahanty and Chico Demmenie"
 __author_email__ = "cdemmenie@gmail.com"

--- a/videohash2/framesextractor.py
+++ b/videohash2/framesextractor.py
@@ -1,5 +1,6 @@
 import os
 import re
+import math
 import shlex
 from shutil import which
 from subprocess import PIPE, Popen, check_output
@@ -26,6 +27,7 @@ class FramesExtractor:
         self,
         video_path: str,
         output_dir: str,
+        video_length: float,
         interval: Union[int, float] = 1,
         ffmpeg_path: Optional[str] = None,
     ) -> None:
@@ -53,6 +55,7 @@ class FramesExtractor:
         """
         self.video_path = video_path
         self.output_dir = output_dir
+        self.video_length = video_length
         self.interval = interval
         self.ffmpeg_path = ""
         if ffmpeg_path:
@@ -114,6 +117,7 @@ class FramesExtractor:
         video_path: Optional[str] = None,
         frames: int = 3,
         ffmpeg_path: Optional[str] = None,
+        video_length: float = 2
     ) -> str:
         """
         Detects the the amount of cropping to remove black bars.
@@ -144,10 +148,17 @@ class FramesExtractor:
             7200,
             14400,
         ]
+        
 
         crop_list = []
 
         for start_time in time_start_list:
+
+            # Stopping the loop if we go beyond the end length of the video.
+            # We round the video length up to make sure we do get the whole
+            # video.
+            if start_time > math.ceil(video_length):
+                break
 
             command = f'"{ffmpeg_path}" -ss {start_time} -i "{video_path}" -vframes {frames} -vf cropdetect -f null -'
 
@@ -185,6 +196,7 @@ class FramesExtractor:
 
         ffmpeg_path = self.ffmpeg_path
         video_path = self.video_path
+        video_length = self.video_length
         output_dir = self.output_dir
 
         if os.name == "posix":
@@ -193,7 +205,8 @@ class FramesExtractor:
             output_dir = shlex.quote(self.output_dir)
 
         crop = FramesExtractor.detect_crop(
-            video_path=video_path, frames=3, ffmpeg_path=ffmpeg_path
+            video_path=video_path, frames=3, ffmpeg_path=ffmpeg_path,
+            video_length=video_length
         )
 
         command = (

--- a/videohash2/framesextractor.py
+++ b/videohash2/framesextractor.py
@@ -118,7 +118,7 @@ class FramesExtractor:
         frames: int = 3,
         ffmpeg_path: Optional[str] = None,
         video_length: float = 2
-    ) -> str:
+    ) -> list:
         """
         Detects the the amount of cropping to remove black bars.
 

--- a/videohash2/utils.py
+++ b/videohash2/utils.py
@@ -21,21 +21,18 @@ def does_path_exists(path: str) -> bool:
     If a directory is supplied then check if it exists.
     If a file is supplied then check if it exists.
 
-    Directory ends with "/" on posix or "\" in windows and files do not.
-
     If directory/file exists returns True else returns False
 
     :return: True if dir or file exists else False.
 
     :rtype: bool
     """
-    if path.endswith("/") or path.endswith("\\"):
-        # it's directory
-        return os.path.isdir(path)
+    if os.path.isdir(path) or os.path.isfile(path):
+        return os.path.exists(path)
 
     else:
         # it's file
-        return os.path.isfile(path)
+        return False
 
 
 def create_and_return_temporary_directory() -> str:

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -37,7 +37,7 @@ class VideoHash:
         storage_path: Optional[str] = None,
         download_worst: bool = False,
         frame_interval: Union[int, float] = 1,
-        do_not_copy: bool = True,
+        do_not_copy: Optional[bool] = True,
     ) -> None:
         """
         :param path: Absolute path of the input video file.

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -37,6 +37,7 @@ class VideoHash:
         storage_path: Optional[str] = None,
         download_worst: bool = False,
         frame_interval: Union[int, float] = 1,
+        do_not_copy: bool = True,
     ) -> None:
         """
         :param path: Absolute path of the input video file.
@@ -74,6 +75,7 @@ class VideoHash:
 
         self._storage_path = self.storage_path
         self.download_worst = download_worst
+        self.do_not_copy = do_not_copy
         self.frame_interval = frame_interval
 
         self.task_uid = VideoHash._get_task_uid()
@@ -84,9 +86,12 @@ class VideoHash:
 
         self.video_duration = video_duration(self.video_path)
 
-        FramesExtractor(self.video_path, self.frames_dir,
-                        video_length=self.video_duration,
-                        interval=self.frame_interval)
+        FramesExtractor(
+            self.video_path,
+            self.frames_dir,
+            video_length=self.video_duration,
+            interval=self.frame_interval,
+        )
 
         self.collage_path = os.path.join(self.collage_dir, "collage.jpg")
 
@@ -292,7 +297,10 @@ class VideoHash:
 
             self.video_path = os.path.join(self.video_dir, (f"video.{extension}"))
 
-            shutil.copyfile(self.path, self.video_path)
+            if self.do_not_copy:
+                os.symlink(self.path, self.video_path)
+            else:
+                shutil.copyfile(self.path, self.video_path)
 
         if self.url:
 
@@ -312,7 +320,10 @@ class VideoHash:
 
             self.video_path = f"{self.video_dir}video.{extension}"
 
-            shutil.copyfile(downloaded_file, self.video_path)
+            if self.do_not_copy:
+                os.symlink(downloaded_file, self.video_path)
+            else:
+                shutil.copyfile(downloaded_file, self.video_path)
 
     def _create_required_dirs_and_check_for_errors(self) -> None:
         """
@@ -678,4 +689,3 @@ class VideoHash:
         # the binary value is prefixed with 0b.
         self.hash = f"0b{self.hash}"
         self.hash_hex: str = VideoHash.bin2hex(self.hash)
-

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -82,7 +82,11 @@ class VideoHash:
 
         self._copy_video_to_video_dir()
 
-        FramesExtractor(self.video_path, self.frames_dir, interval=self.frame_interval)
+        self.video_duration = video_duration(self.video_path)
+
+        FramesExtractor(self.video_path, self.frames_dir,
+                        video_length=self.video_duration,
+                        interval=self.frame_interval)
 
         self.collage_path = os.path.join(self.collage_dir, "collage.jpg")
 
@@ -104,7 +108,6 @@ class VideoHash:
         self.image = Image.open(self.collage_path)
         self.bits_in_hash = 64
         self.similar_percentage = 15
-        self.video_duration = video_duration(self.video_path)
 
         self._calc_hash()
 
@@ -675,3 +678,4 @@ class VideoHash:
         # the binary value is prefixed with 0b.
         self.hash = f"0b{self.hash}"
         self.hash_hex: str = VideoHash.bin2hex(self.hash)
+


### PR DESCRIPTION
Changelog:
- Roughly halved average hashing time by using `video_duration` to limit `FramesExtractor.detect_crop` as suggested [here](https://github.com/akamhy/videohash/issues/96#issuecomment-1962821744).
- Added `do_not_copy` option to `VideoHash`. If set to `False` it will copy the video into temporary storage, it's set to `True` by default. This also saves on memory and improves performance. As suggested [here](https://github.com/akamhy/videohash/pull/97).
- Fixed `stdint` issue with subprocesses as suggested [here](https://github.com/akamhy/videohash/pull/99).
- Added new wiki to README which can be found [here](https://github.com/Demmenie/videohash2/wiki).