### PR TITLE
V3.2.0

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci_mac_os.yml
+++ b/.github/workflows/ci_mac_os.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.8, '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci_mac_os.yml
+++ b/.github/workflows/ci_mac_os.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.8, '3.9', '3.10', '3.11']
+        python-version: ['3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.8, '3.9', '3.10', '3.11']
+        python-version: ['3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.8, '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: ['3.8, '3.9', '3.10', '3.11']
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,9 @@ submitting a pull request.
 ### Testing
 
 Before submitting a pull request, make sure the code passes all the tests and is
-formatted by black:
+formatted by black. I would recommend testing this package in an isolated
+environment, preferably a VM; certainly, avoid doing testing in WSL as it can
+lead to files being erroneously removed / corrupted from your machine.
 
 ```bash
 # Inside the project root (directory containing this file)

--- a/tests/test_videoduration.py
+++ b/tests/test_videoduration.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from videohash2.exceptions import DidNotSupplyPathOrUrl, StoragePathDoesNotExist
+from videohash2.exceptions import DidNotSupplyPathOrUrl
 from videohash2.videoduration import video_duration
 from videohash2.utils import create_and_return_temporary_directory
 
@@ -22,7 +22,7 @@ def test_video_duration():
 
     assert (video_duration(path=video_path) - 52.08) < 0.1
 
-    url = "https://github.com/Demmenie/videohash2/blob/main/assets/rocket.mkv"
+    url = "https://raw.githubusercontent.com/demmenie/videohash2/main/assets/rocket.mkv"
 
     assert (video_duration(url=url) - 52.08) < 0.1
 

--- a/tests/test_videoduration.py
+++ b/tests/test_videoduration.py
@@ -1,8 +1,9 @@
 import os
 
 import pytest
-
+from videohash2.exceptions import DidNotSupplyPathOrUrl, StoragePathDoesNotExist
 from videohash2.videoduration import video_duration
+from videohash2.utils import create_and_return_temporary_directory
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -19,4 +20,18 @@ def test_video_duration():
         + "rocket.mkv"
     )
 
-    assert (video_duration(video_path) - 52.08) < 0.1
+    assert (video_duration(path=video_path) - 52.08) < 0.1
+
+    url = "https://github.com/Demmenie/videohash2/blob/main/assets/rocket.mkv"
+
+    assert (video_duration(url=url) - 52.08) < 0.1
+
+    with pytest.raises(DidNotSupplyPathOrUrl):
+        video_duration(url=None, path=None)
+
+    with pytest.raises(ValueError):
+        storage_path = os.path.join(
+            create_and_return_temporary_directory(),
+            ("thisdirdoesnotexist" + os.path.sep),
+        )
+        video_duration(url="https://example.com", path=storage_path)

--- a/tests/test_videohash.py
+++ b/tests/test_videohash.py
@@ -14,7 +14,6 @@ def test_all():
     source1 = (
         "https://raw.githubusercontent.com/demmenie/videohash2/main/assets/rocket.mkv"
     )
-    print("Hashing source1.")
     videohash1 = VideoHash(url=source1, frame_interval=3)
     hash1 = videohash1.hash
     hash_hex1 = videohash1.hash_hex
@@ -57,7 +56,6 @@ def test_all():
         + "rocket.mkv"
     )
 
-    print("Hashing source2.")
     videohash2 = VideoHash(path=source2, frame_interval=3)
     hash2 = videohash2.hash
     hash_hex2 = videohash2.hash_hex
@@ -66,7 +64,6 @@ def test_all():
 
     source3 = "https://www.youtube.com/watch?v=PapBjpzRhnA"
 
-    print("Hashing source3.")
     videohash3 = VideoHash(url=source3)
     hash3 = videohash3.hash
     hash_hex3 = videohash3.hash_hex

--- a/tests/test_videohash.py
+++ b/tests/test_videohash.py
@@ -12,10 +12,10 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 def test_all():
 
     source1 = (
-        "https://raw.githubusercontent.com/akamhy/videohash/main/assets/rocket.mkv"
+        "https://raw.githubusercontent.com/demmenie/videohash2/main/assets/rocket.mkv"
     )
+    print("Hashing source1.")
     videohash1 = VideoHash(url=source1, frame_interval=3)
-    videohash1.delete_storage_path()
     hash1 = videohash1.hash
     hash_hex1 = videohash1.hash_hex
     assert hash1 == "0b1010100110101001111111111111101101011110101100010000001100000011"
@@ -56,6 +56,8 @@ def test_all():
         + os.path.sep
         + "rocket.mkv"
     )
+
+    print("Hashing source2.")
     videohash2 = VideoHash(path=source2, frame_interval=3)
     hash2 = videohash2.hash
     hash_hex2 = videohash2.hash_hex
@@ -63,6 +65,8 @@ def test_all():
     assert hash_hex2 == "0xa9a9fffb5eb10303"
 
     source3 = "https://www.youtube.com/watch?v=PapBjpzRhnA"
+
+    print("Hashing source3.")
     videohash3 = VideoHash(url=source3)
     hash3 = videohash3.hash
     hash_hex3 = videohash3.hash_hex
@@ -142,3 +146,6 @@ def test_all():
             create_and_return_temporary_directory(), "file_extension_less_video"
         )
         VideoHash(path=path)
+
+if __name__ == "__main__":
+    test_all()

--- a/tests/test_videohash.py
+++ b/tests/test_videohash.py
@@ -90,7 +90,7 @@ def test_all():
     assert videohash1 != videohash4
     assert videohash2 != videohash4
     assert videohash3 != videohash4
-    assert videohash3.is_diffrent(videohash4)
+    assert videohash3.is_different(videohash4)
 
     with pytest.raises(ValueError):
         # not padded with 0x

--- a/videohash2/utils.py
+++ b/videohash2/utils.py
@@ -1,7 +1,8 @@
 import os
 import tempfile
-from pathlib import Path
+import random
 from typing import List
+from pathlib import Path
 
 
 def get_list_of_all_files_in_dir(directory: str) -> List[str]:
@@ -34,7 +35,6 @@ def does_path_exists(path: str) -> bool:
         # it's file
         return False
 
-
 def create_and_return_temporary_directory() -> str:
     """
     create a temporary directory where we can store the video, frames and the
@@ -47,3 +47,25 @@ def create_and_return_temporary_directory() -> str:
     path = os.path.join(tempfile.mkdtemp(), ("temp_storage_dir" + os.path.sep))
     Path(path).mkdir(parents=True, exist_ok=True)
     return path
+
+def _get_task_uid() -> str:
+    """
+    Returns an unique task id for the instance. Task id is used to
+    differentiate the instance files from the other unrelated files.
+
+    We want to make sure that only the instance is manipulating the instance files
+    and no other process nor user by accident deletes or edits instance files while
+    we are still processing.
+
+    :return: instance's unique task id.
+
+    :rtype: str
+    """
+    sys_random = random.SystemRandom()
+
+    return "".join(
+        sys_random.choice(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        )
+        for _ in range(20)
+    )

--- a/videohash2/videocopy.py
+++ b/videohash2/videocopy.py
@@ -16,7 +16,7 @@ def _copy_video_to_video_dir(
         do_not_copy: Optional[bool] = True,
         download_worst: bool = False,
         url: Optional[str] = None,
-        path: Optional[str] = None) -> tuple:
+        path: Optional[str] = None) -> str:
     """
     Copy the video from the path to the video directory.
 
@@ -78,7 +78,7 @@ def _copy_video_to_video_dir(
         else:
             shutil.copyfile(downloaded_file, video_path)
 
-    return (video_path, downloaded_file)
+    return video_path
 
 def _create_required_dirs_and_check_for_errors(
         url: Optional[str] = None,
@@ -153,5 +153,4 @@ def _create_required_dirs_and_check_for_errors(
         parents=True, exist_ok=True
     )
 
-    return (video_dir, video_download_dir, frames_dir, tiles_dir, collage_dir, 
-            horizontally_concatenated_image_dir)
+    return video_dir, video_download_dir, frames_dir, tiles_dir, collage_dir, horizontally_concatenated_image_dir

--- a/videohash2/videocopy.py
+++ b/videohash2/videocopy.py
@@ -1,0 +1,157 @@
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Optional
+from .exceptions import DidNotSupplyPathOrUrl, StoragePathDoesNotExist
+from .downloader import Download
+from .utils import (get_list_of_all_files_in_dir,
+                    does_path_exists,
+                    create_and_return_temporary_directory,
+                    _get_task_uid)
+
+def _copy_video_to_video_dir(
+        video_dir: str,
+        video_download_dir: str,
+        do_not_copy: Optional[bool] = True,
+        download_worst: bool = False,
+        url: Optional[str] = None,
+        path: Optional[str] = None) -> tuple:
+    """
+    Copy the video from the path to the video directory.
+
+    Copying avoids issues such as the user or some other
+    process deleting the instance files while we are still
+    processing.
+
+    If instead of the path the uploader specified an url,
+    then download the video and copy the file to video
+    directory.
+
+
+    :return: None
+
+    :rtype: NoneType
+
+    :raises ValueError: If the path supplied by the end user
+                        lacks an extension. E.g. webm, mkv and mp4.
+    """
+    video_path: str = ""
+
+    if path:
+        # create a copy of the video at self.storage_path
+        match = re.search(r"\.([^.]+$)", path)
+
+        if match:
+            extension = match.group(1)
+
+        else:
+            raise ValueError("File name (path) does not have an extension.")
+
+        video_path = os.path.join(video_dir, (f"video.{extension}"))
+
+        if do_not_copy:
+            os.symlink(path, video_path)
+        else:
+            shutil.copyfile(path, video_path)
+
+    if url:
+
+        Download(
+            url,
+            video_download_dir,
+            worst=download_worst,
+        )
+
+        downloaded_file = get_list_of_all_files_in_dir(video_download_dir)[0]
+        match = re.search(r"\.(.*?)$", downloaded_file)
+
+        extension = "mkv"
+
+        if match:
+            extension = match.group(1)
+
+        video_path = f"{video_dir}video.{extension}"
+
+        if do_not_copy:
+            os.symlink(downloaded_file, video_path)
+        else:
+            shutil.copyfile(downloaded_file, video_path)
+
+    return (video_path, downloaded_file)
+
+def _create_required_dirs_and_check_for_errors(
+        url: Optional[str] = None,
+        path: Optional[str] = None,
+        storage_path: Optional[str] = None
+) -> tuple:
+    """
+    Creates important directories before the main processing starts.
+
+    The instance files are stored in these directories, no need to worry
+    about the end user or some other processes interfering with the instance
+    generated files.
+
+
+    :raises DidNotSupplyPathOrUrl: If the user forgot to specify both the
+                                    path and the url. One of them must be
+                                    specified for creating the object.
+
+    :raises ValueError: If user passed both path and url. Only pass
+                        one of them if the file is available on both
+                        then pass the path only.
+
+    :raises StoragePathDoesNotExist: If the storage path specified by the
+                                        user does not exist.
+
+    :return: None
+
+    :rtype: NoneType
+    """
+    if not path and not url:
+        raise DidNotSupplyPathOrUrl(
+            "You must specify either a path or an URL of the video."
+        )
+
+    if path and url:
+        raise ValueError("Specify either a path or an URL and NOT both.")
+
+    if not storage_path:
+        storage_path = create_and_return_temporary_directory()
+    if not does_path_exists(storage_path):
+        raise StoragePathDoesNotExist(
+            f"Storage path '{storage_path}' does not exist."
+        )
+
+    os_path_sep = os.path.sep
+
+    storage_path = os.path.join(
+        storage_path, (f"{_get_task_uid()}{os_path_sep}")
+    )
+
+    video_dir = os.path.join(storage_path, (f"video{os_path_sep}"))
+    Path(video_dir).mkdir(parents=True, exist_ok=True)
+
+    video_download_dir = os.path.join(
+        storage_path, (f"downloadedvideo{os_path_sep}")
+    )
+    Path(video_download_dir).mkdir(parents=True, exist_ok=True)
+
+    frames_dir = os.path.join(storage_path, (f"frames{os_path_sep}"))
+    Path(frames_dir).mkdir(parents=True, exist_ok=True)
+
+    tiles_dir = os.path.join(storage_path, (f"tiles{os_path_sep}"))
+    Path(tiles_dir).mkdir(parents=True, exist_ok=True)
+
+    collage_dir = os.path.join(storage_path, (f"collage{os_path_sep}"))
+    Path(collage_dir).mkdir(parents=True, exist_ok=True)
+
+    horizontally_concatenated_image_dir = os.path.join(
+        storage_path, (f"horizontally_concatenated_image{os_path_sep}")
+    )
+    Path(horizontally_concatenated_image_dir).mkdir(
+        parents=True, exist_ok=True
+    )
+
+    return (video_dir, video_download_dir, frames_dir, tiles_dir, collage_dir, 
+            horizontally_concatenated_image_dir)

--- a/videohash2/videoduration.py
+++ b/videohash2/videoduration.py
@@ -49,17 +49,17 @@ def video_duration(url: Optional[str] = None,
         ffmpeg_path = str(which("ffmpeg"))
 
     if url:
-        (video_dir, video_download_dir
-        ) = _create_required_dirs_and_check_for_errors(
+        video_dir, video_download_dir = _create_required_dirs_and_check_for_errors(
             url=url,
             storage_path=storage_path
-            )[0:1]
+            )[0:2]
 
         path = _copy_video_to_video_dir(
             video_dir,
             video_download_dir,
-            do_not_copy=do_not_copy
-        )[0]
+            do_not_copy=do_not_copy,
+            url=url
+        )
 
     command = f'"{ffmpeg_path}" -i "{path}"'
     process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)

--- a/videohash2/videoduration.py
+++ b/videohash2/videoduration.py
@@ -58,6 +58,7 @@ def video_duration(url: Optional[str] = None,
             video_dir,
             video_download_dir,
             do_not_copy=do_not_copy,
+            download_worst=True,
             url=url
         )
 

--- a/videohash2/videoduration.py
+++ b/videohash2/videoduration.py
@@ -2,18 +2,33 @@ import re
 from shutil import which
 from subprocess import PIPE, Popen
 from typing import Optional
+from .exceptions import DidNotSupplyPathOrUrl
+from .videocopy import (_create_required_dirs_and_check_for_errors,
+                    _copy_video_to_video_dir)
 
 # Module to determine the length of video.
 # The length is found by the FFmpeg, the output of video_duration is in seconds.
 
 
-def video_duration(video_path: str, ffmpeg_path: Optional[str] = None) -> float:
+def video_duration(url: Optional[str] = None,
+                   path: Optional[str] = None,
+                   storage_path: Optional[str] = None,
+                   do_not_copy: Optional[bool] = True,
+                   ffmpeg_path: Optional[str] = None
+                   ) -> float:
+    
     """
     Retrieve the exact video duration as echoed by the FFmpeg and return
     the duration in seconds. Maximum duration supported is 999 hours, above
     which the regex is doomed to fail(no match).
 
-    :param video_path: Absolute path of the video file.
+    :param url: A URL that leads to a video.
+
+    :param path: Absolute path of the video file.
+
+    :param storage_path: Optional, path to where you want to store the video.
+
+    :param do_not_copy: Used when you want to save the video, defaults to True.
 
     :param ffmpeg_path: Path of the FFmpeg software if not in path.
 
@@ -22,10 +37,31 @@ def video_duration(video_path: str, ffmpeg_path: Optional[str] = None) -> float:
     :rtype: float
     """
 
+    if not path and not url:
+        raise DidNotSupplyPathOrUrl(
+            "You must specify either a path or an URL of the video."
+        )
+    
+    if path and url:
+        raise ValueError("Specify either a path or an URL and NOT both.")
+
     if not ffmpeg_path:
         ffmpeg_path = str(which("ffmpeg"))
 
-    command = f'"{ffmpeg_path}" -i "{video_path}"'
+    if url:
+        (video_dir, video_download_dir
+        ) = _create_required_dirs_and_check_for_errors(
+            url=url,
+            storage_path=storage_path
+            )[0:1]
+
+        path = _copy_video_to_video_dir(
+            video_dir,
+            video_download_dir,
+            do_not_copy=do_not_copy
+        )[0]
+
+    command = f'"{ffmpeg_path}" -i "{path}"'
     process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
     output, error = process.communicate()
 

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -404,10 +404,10 @@ class VideoHash:
         else:
             return False
 
-    def is_diffrent(self, other: object) -> bool:
+    def is_different(self, other: object) -> bool:
         """
         Refer to the is_similar,
-        if not similar then diffrent.
+        if not similar then different.
         """
 
         if not self.is_similar(other):

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -1,8 +1,6 @@
 import os
 import random
-import re
 import shutil
-from pathlib import Path
 from math import ceil
 from typing import List, Optional, Union
 
@@ -12,15 +10,16 @@ from imagedominantcolour import DominantColour
 from PIL import Image
 
 from .collagemaker import MakeCollage
-from .downloader import Download
-from .exceptions import DidNotSupplyPathOrUrl, StoragePathDoesNotExist
 from .framesextractor import FramesExtractor
 from .tilemaker import make_tile
 from .utils import (
     create_and_return_temporary_directory,
     does_path_exists,
     get_list_of_all_files_in_dir,
+    _get_task_uid
 )
+from .videocopy import (_create_required_dirs_and_check_for_errors,
+    _copy_video_to_video_dir)
 from .videoduration import video_duration
 
 
@@ -78,13 +77,31 @@ class VideoHash:
         self.do_not_copy = do_not_copy
         self.frame_interval = frame_interval
 
-        self.task_uid = VideoHash._get_task_uid()
+        self.task_uid = _get_task_uid()
 
-        self._create_required_dirs_and_check_for_errors()
+        (self.video_dir,
+         self.video_download_dir,
+         self.frames_dir,
+         self.tiles_dir,
+         self.collage_dir,
+         self.horizontally_concatenated_image_dir
+        ) = _create_required_dirs_and_check_for_errors(
+            url=self.url,
+            path=self.path,
+            storage_path=self.storage_path
+        )
 
-        self._copy_video_to_video_dir()
+        (self.video_path,
+         self.downloaded_file) = _copy_video_to_video_dir(
+             video_dir=self.video_dir,
+             video_download_dir=self.video_download_dir,
+             do_not_copy=self.do_not_copy,
+             download_worst=self.download_worst,
+             url=self.url,
+             path=self.path
+         )
 
-        self.video_duration = video_duration(self.video_path)
+        self.video_duration = video_duration(path=self.video_path)
 
         FramesExtractor(
             self.video_path,
@@ -263,137 +280,6 @@ class VideoHash:
             + "hexadecimal/binary strings or instance of VideoHash class."
         )
 
-    def _copy_video_to_video_dir(self) -> None:
-        """
-        Copy the video from the path to the video directory.
-
-        Copying avoids issues such as the user or some other
-        process deleting the instance files while we are still
-        processing.
-
-        If instead of the path the uploader specified an url,
-        then download the video and copy the file to video
-        directory.
-
-
-        :return: None
-
-        :rtype: NoneType
-
-        :raises ValueError: If the path supplied by the end user
-                            lacks an extension. E.g. webm, mkv and mp4.
-        """
-        self.video_path: str = ""
-
-        if self.path:
-            # create a copy of the video at self.storage_path
-            match = re.search(r"\.([^.]+$)", self.path)
-
-            if match:
-                extension = match.group(1)
-
-            else:
-                raise ValueError("File name (path) does not have an extension.")
-
-            self.video_path = os.path.join(self.video_dir, (f"video.{extension}"))
-
-            if self.do_not_copy:
-                os.symlink(self.path, self.video_path)
-            else:
-                shutil.copyfile(self.path, self.video_path)
-
-        if self.url:
-
-            Download(
-                self.url,
-                self.video_download_dir,
-                worst=self.download_worst,
-            )
-
-            downloaded_file = get_list_of_all_files_in_dir(self.video_download_dir)[0]
-            match = re.search(r"\.(.*?)$", downloaded_file)
-
-            extension = "mkv"
-
-            if match:
-                extension = match.group(1)
-
-            self.video_path = f"{self.video_dir}video.{extension}"
-
-            if self.do_not_copy:
-                os.symlink(downloaded_file, self.video_path)
-            else:
-                shutil.copyfile(downloaded_file, self.video_path)
-
-    def _create_required_dirs_and_check_for_errors(self) -> None:
-        """
-        Creates important directories before the main processing starts.
-
-        The instance files are stored in these directories, no need to worry
-        about the end user or some other processes interfering with the instance
-        generated files.
-
-
-        :raises DidNotSupplyPathOrUrl: If the user forgot to specify both the
-                                       path and the url. One of them must be
-                                       specified for creating the object.
-
-        :raises ValueError: If user passed both path and url. Only pass
-                            one of them if the file is available on both
-                            then pass the path only.
-
-        :raises StoragePathDoesNotExist: If the storage path specified by the
-                                         user does not exist.
-
-        :return: None
-
-        :rtype: NoneType
-        """
-        if not self.path and not self.url:
-            raise DidNotSupplyPathOrUrl(
-                "You must specify either a path or an URL of the video."
-            )
-
-        if self.path and self.url:
-            raise ValueError("Specify either a path or an URL and NOT both.")
-
-        if not self.storage_path:
-            self.storage_path = create_and_return_temporary_directory()
-        if not does_path_exists(self.storage_path):
-            raise StoragePathDoesNotExist(
-                f"Storage path '{self.storage_path}' does not exist."
-            )
-
-        os_path_sep = os.path.sep
-
-        self.storage_path = os.path.join(
-            self.storage_path, (f"{self.task_uid}{os_path_sep}")
-        )
-
-        self.video_dir = os.path.join(self.storage_path, (f"video{os_path_sep}"))
-        Path(self.video_dir).mkdir(parents=True, exist_ok=True)
-
-        self.video_download_dir = os.path.join(
-            self.storage_path, (f"downloadedvideo{os_path_sep}")
-        )
-        Path(self.video_download_dir).mkdir(parents=True, exist_ok=True)
-
-        self.frames_dir = os.path.join(self.storage_path, (f"frames{os_path_sep}"))
-        Path(self.frames_dir).mkdir(parents=True, exist_ok=True)
-
-        self.tiles_dir = os.path.join(self.storage_path, (f"tiles{os_path_sep}"))
-        Path(self.tiles_dir).mkdir(parents=True, exist_ok=True)
-
-        self.collage_dir = os.path.join(self.storage_path, (f"collage{os_path_sep}"))
-        Path(self.collage_dir).mkdir(parents=True, exist_ok=True)
-
-        self.horizontally_concatenated_image_dir = os.path.join(
-            self.storage_path, (f"horizontally_concatenated_image{os_path_sep}")
-        )
-        Path(self.horizontally_concatenated_image_dir).mkdir(
-            parents=True, exist_ok=True
-        )
-
     def is_similar(self, other: object) -> bool:
         """
         If 'similar_percentage' of bits are similar
@@ -444,29 +330,6 @@ class VideoHash:
             )
 
         shutil.rmtree(directory, ignore_errors=True, onerror=None)
-
-    @staticmethod
-    def _get_task_uid() -> str:
-        """
-        Returns an unique task id for the instance. Task id is used to
-        differentiate the instance files from the other unrelated files.
-
-        We want to make sure that only the instance is manipulating the instance files
-        and no other process nor user by accident deletes or edits instance files while
-        we are still processing.
-
-        :return: instance's unique task id.
-
-        :rtype: str
-        """
-        sys_random = random.SystemRandom()
-
-        return "".join(
-            sys_random.choice(
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-            )
-            for _ in range(20)
-        )
 
     def hamming_distance(
         self,

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -321,8 +321,6 @@ class VideoHash:
         :rtype: NoneType
         """
 
-        print("Deleting path:", self.storage_path)
-
         directory = self.storage_path
 
         if not self._storage_path:

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -91,8 +91,7 @@ class VideoHash:
             storage_path=self.storage_path
         )
 
-        (self.video_path,
-         self.downloaded_file) = _copy_video_to_video_dir(
+        self.video_path = _copy_video_to_video_dir(
              video_dir=self.video_dir,
              video_download_dir=self.video_download_dir,
              do_not_copy=self.do_not_copy,
@@ -321,6 +320,9 @@ class VideoHash:
 
         :rtype: NoneType
         """
+
+        print("Deleting path:", self.storage_path)
+
         directory = self.storage_path
 
         if not self._storage_path:


### PR DESCRIPTION
Changelog:
- Added URL and do_not_copy options to video_duration.
- Moved _copy_video_to_video_dir() and _create_required_dirs_and_check_for_errors() to new file "videocopy.py" to facilitate the last point.
- Adjusted test_videoduration.py and test_videohash.py to facilitate this and ensure that it's tested properly.
- Removed support for Python versions <=3.7 to comply with yt-dlp support.