### PR TITLE
Add yt_dlp_extra_options argument to VideoHash

### DIFF
--- a/videohash2/downloader.py
+++ b/videohash2/downloader.py
@@ -1,5 +1,6 @@
 from shutil import which
 from subprocess import PIPE, Popen
+from typing import Optional
 
 from .exceptions import DownloadFailed, DownloadOutPutDirDoesNotExist
 from .utils import does_path_exists, get_list_of_all_files_in_dir
@@ -20,6 +21,7 @@ class Download:
         self,
         url: str,
         output_dir: str,
+        yt_dlp_extra_options: Optional[str] = None,
         worst: bool = True,
     ) -> None:
         """
@@ -40,6 +42,7 @@ class Download:
         self.url = url
         self.output_dir = output_dir
         self.worst = worst
+        self.yt_dlp_extra_options= yt_dlp_extra_options
 
         if not does_path_exists(self.output_dir):
             raise DownloadOutPutDirDoesNotExist(
@@ -68,6 +71,7 @@ class Download:
             + '"'
             + self.url
             + '"'
+            + (f' {self.yt_dlp_extra_options} ' if self.yt_dlp_extra_options else '')
             + " -o "
             + '"'
             + self.output_dir

--- a/videohash2/videocopy.py
+++ b/videohash2/videocopy.py
@@ -13,6 +13,7 @@ from .utils import (get_list_of_all_files_in_dir,
 def _copy_video_to_video_dir(
         video_dir: str,
         video_download_dir: str,
+        yt_dlp_extra_options: Optional[str],
         do_not_copy: Optional[bool] = True,
         download_worst: bool = False,
         url: Optional[str] = None,
@@ -61,6 +62,7 @@ def _copy_video_to_video_dir(
             url,
             video_download_dir,
             worst=download_worst,
+            yt_dlp_extra_options=yt_dlp_extra_options,
         )
 
         downloaded_file = get_list_of_all_files_in_dir(video_download_dir)[0]

--- a/videohash2/videoduration.py
+++ b/videohash2/videoduration.py
@@ -14,7 +14,8 @@ def video_duration(url: Optional[str] = None,
                    path: Optional[str] = None,
                    storage_path: Optional[str] = None,
                    do_not_copy: Optional[bool] = True,
-                   ffmpeg_path: Optional[str] = None
+                   ffmpeg_path: Optional[str] = None,
+                   yt_dlp_extra_options: Optional[str] = None
                    ) -> float:
     
     """
@@ -59,7 +60,8 @@ def video_duration(url: Optional[str] = None,
             video_download_dir,
             do_not_copy=do_not_copy,
             download_worst=True,
-            url=url
+            url=url,
+            yt_dlp_extra_options=yt_dlp_extra_options
         )
 
     command = f'"{ffmpeg_path}" -i "{path}"'

--- a/videohash2/videohash.py
+++ b/videohash2/videohash.py
@@ -37,6 +37,7 @@ class VideoHash:
         download_worst: bool = False,
         frame_interval: Union[int, float] = 1,
         do_not_copy: Optional[bool] = True,
+        yt_dlp_extra_options:Optional[str] = None
     ) -> None:
         """
         :param path: Absolute path of the input video file.
@@ -76,6 +77,7 @@ class VideoHash:
         self.download_worst = download_worst
         self.do_not_copy = do_not_copy
         self.frame_interval = frame_interval
+        self.yt_dlp_extra_options=yt_dlp_extra_options
 
         self.task_uid = _get_task_uid()
 
@@ -98,7 +100,8 @@ class VideoHash:
              do_not_copy=self.do_not_copy,
              download_worst=self.download_worst,
              url=self.url,
-             path=self.path
+             path=self.path,
+             yt_dlp_extra_options=self.yt_dlp_extra_options
          )
 
         self.video_duration = video_duration(path=self.video_path)


### PR DESCRIPTION
Description:

I have added a new argument, yt_dlp_extra_options, to the VideoHash class. This allows users to pass additional options directly to yt-dlp, such as --cookies-from-browser, which can be necessary for certain websites.

Motivation:

This feature enhances the flexibility and control over the behavior of yt-dlp within the VideoHash process. By allowing extra options, users can better handle specific use cases that require advanced configurations.

Changes:
- Added the yt_dlp_extra_options argument to VideoHash.

Example usage:

    video_hash = VideoHash(url=video_link, yt_dlp_extra_options="--cookies-from-browser firefox")

Additional Notes:
- The wiki will need to be updated to include details about the new yt_dlp_extra_options argument and its usage.

This change should not affect existing functionality, but it provides a more powerful interface for those who need it.

Please review the changes and let me know if further adjustments are needed. Thank you!